### PR TITLE
fix: add additional source file package data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,14 @@ setup(
         ],
     ),
     package_data={
+        "moe_gen": [
+            "**/*.cpp",
+            "**/*.h",
+            "**/*.cc",
+            "**/*.hpp",
+            "**/*.py",
+            "**/*.so",
+        ],
         "moe_gen.core_engine": ["**/*.so"],
     },
     include_package_data=True,


### PR DESCRIPTION
## Description
Include additional source files in the binary distribution (`wheel`).

## Motivation
As reported in #19, when users fail to load the pre-compiled shared library, the Torch extension will attempt to compile from source. Currently, the required C++ source files are only packaged in the source distribution (`sdist`), and the wheel distribution to lack necessary files for recompilation.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Gen/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
