### PR TITLE
docs: add about section and 4-devices performance to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - [2025-03] MoE-Gen V0.1 release. Empower DeepSeek-R1-671B inference on **a single** NVIDIA A5000 with prefill throughput **204 tokens/s**, decoding throughput **17 tokens/s**. We dequantize to BF16 in the runtime to have **FULL** precision (**_without any quantization_**) and to be runnable on Ampere architecture. Data parallel on multiple devices supported.
 
 # About
-MoE-Gen is an efficient serving engine optimized specifically for **Mixture-of-Expert(MoE)** based large language models. It is tailored for bulk **offline inference** tasks and **limited GPU resources**. It enables low cost serving for latency-insensitive applications. 
+MoE-Gen is an efficient serving engine optimized specifically for **Mixture-of-Expert(MoE)** based large language models. It is tailored for bulk **offline inference** tasks and **limited GPU resources**. It enables low cost serving for latency-insensitive applications.
 
 **Core Features**
 
@@ -40,8 +40,8 @@ MoE-Gen is an efficient serving engine optimized specifically for **Mixture-of-E
 | **SGLang**    | Not Supported              | Not Supported           |Not Supported           |Not Supported           |
 | **vLLM**      | Not Supported              | 97 / 0.9                |147/2                   |1347/31|
 | **Llama.cpp** | 5.7/0.9                  | 23/1                    |110/2                   |328/4|
-| **MoE-Gen**   | **204/27**                 | **787/49**              |**907/91**              |**2790/469**|  
-</div>  
+| **MoE-Gen**   | **204/27**                 | **787/49**              |**907/91**              |**2790/469**|
+</div>
 
 
 ## Release Plan

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 - [2025-03-21] Integrated mat absorption for DeepSeek MLA. On single A5000-24GB, **DeepSeek-R1-671B BF16 decoding: 27 token/s**. DeepSeek-V2-236B decoding: 49 tokens/s.
 - [2025-03] MoE-Gen V0.1 release. Empower DeepSeek-R1-671B inference on **a single** NVIDIA A5000 with prefill throughput **204 tokens/s**, decoding throughput **17 tokens/s**. We dequantize to BF16 in the runtime to have **FULL** precision (**_without any quantization_**) and to be runnable on Ampere architecture. Data parallel on multiple devices supported.
 
+# About
+MoE-Gen is an efficient serving engine optimized specifically for **Mixture-of-Expert(MoE)** based large language models. It is tailored for bulk **offline inference** tasks and **limited GPU resources**. It enables low cost serving for latency-insensitive applications. 
+
+**Core Features**
+
+- **Module-Based Batching**: A fine-grained batching strategy ensures consistently high GPU utilization throughout every forward pass.
+- **Efficient Data Swapping Engine**: Supports inference of large-scale models (e.g., DeepSeek-R1) on constrained hardware setups such as single NVIDIA A5000 or RTX 4090 GPUs, aggressively maximizing overlap between computation and memory transfers to achieve optimal efficiency.
+- **Heterogeneous Computing**: Leverages under-utilized CPU resources and optimizes host data locality to significantly boost overall throughput.
+
 # Supported Models
 - **DeepSeek-R1/V3-671B. FULL Precision.**
 - DeepSeek-V2 Family: V2, V2.5, V2-Lite, V2-Coder.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,26 @@ MoE-Gen is an efficient serving engine optimized specifically for **Mixture-of-E
 | **SGLang**    | Not Supported              | Not Supported           |Not Supported           |Not Supported           |
 | **vLLM**      | Not Supported              | 97 / 0.9                |147/2                   |1347/31|
 | **Llama.cpp** | 5.7/0.9                  | 23/1                    |110/2                   |328/4|
-| **MoE-Gen**   | **204/27**                 | **787/49**              |**907/91**              |**2790/469**|
+| **MoE-Gen**   | **204/27**                 | **787/49**              |**907/91**              |**2790/469**|  
+</div>  
+
+
+
+**4xA5000 + 1TB Host Memory.** Prompt length 512 tokens, decoding length 256 tokens. Prefill/decoding throughput in tokens/s.
+
+<div align="center">
+
+|               | DeepSeek-R1/V3 (671B-W8A16)| DeekSeek-V2 (236B-W16A16)|
+|:-------------:|:--------------------------:|:-----------------------:|
+| **SGLang**    | Not Supported              | Not Supported           |
+| **vLLM**      | Not Supported              | 97 / 0.9                |
+| **MoE-Gen**   | **204/27**                 | **2188/196**              |
 
 </div>
 
 ## Release Plan
 
-* Integrate DeepSeek FlashMLA and DeepGEMM.
+* Integrate speculative decoding for DeepSeek-R1.
 * Optimization on Ada and Hopper architecture.
 * Support moonshotai/Moonlight MoE.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </div>
 
 # Latest News
-- [2025-03-21] Integrated mat absorption for DeepSeek MLA. On single A5000-24GB, **DeepSeek-R1-671B BF16 decoding: 27 token/s**. DeepSeek-V2-236B decoding: 49 tokens/s.
+- [2025-03-21] Integrated mat absorption for DeepSeek MLA. On single A5000-24GB, **DeepSeek-R1-671B BF16 decoding: 27 token/s**. DeepSeek-V2-236B decoding: 49 tokens/s. On 4xA5000 + 1TB host memory, DeepSeek-V2-236B Prefill.Decoding: 2925/196 tokens/s.
 - [2025-03] MoE-Gen V0.1 release. Empower DeepSeek-R1-671B inference on **a single** NVIDIA A5000 with prefill throughput **204 tokens/s**, decoding throughput **17 tokens/s**. We dequantize to BF16 in the runtime to have **FULL** precision (**_without any quantization_**) and to be runnable on Ampere architecture. Data parallel on multiple devices supported.
 
 # About
@@ -43,19 +43,6 @@ MoE-Gen is an efficient serving engine optimized specifically for **Mixture-of-E
 | **MoE-Gen**   | **204/27**                 | **787/49**              |**907/91**              |**2790/469**|  
 </div>  
 
-
-
-**4xA5000 + 1TB Host Memory.** Prompt length 512 tokens, decoding length 256 tokens. Prefill/decoding throughput in tokens/s.
-
-<div align="center">
-
-|               | DeepSeek-R1/V3 (671B-W8A16)| DeekSeek-V2 (236B-W16A16)|
-|:-------------:|:--------------------------:|:-----------------------:|
-| **SGLang**    | Not Supported              | Not Supported           |
-| **vLLM**      | Not Supported              | 97 / 0.9                |
-| **MoE-Gen**   | **204/27**                 | **2188/196**              |
-
-</div>
 
 ## Release Plan
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 </div>
 
 # Latest News
-- [2025-03-21] Integrated mat absorption for DeepSeek MLA. On single A5000-24GB, **DeepSeek-R1-671B BF16 decoding: 27 token/s**. DeepSeek-V2-236B decoding: 49 tokens/s. On 4xA5000 + 1TB host memory, DeepSeek-V2-236B Prefill.Decoding: 2925/196 tokens/s.
-- [2025-03] MoE-Gen V0.1 release. Empower DeepSeek-R1-671B inference on **a single** NVIDIA A5000 with prefill throughput **204 tokens/s**, decoding throughput **17 tokens/s**. We dequantize to BF16 in the runtime to have **FULL** precision (**_without any quantization_**) and to be runnable on Ampere architecture. Data parallel on multiple devices supported.
+- [2025-03-21] Integrated mat absorption for DeepSeek MLA. On single A5000-24GB, **DeepSeek-R1-671B BF16 decoding: 27 token/s**. DeepSeek-V2-236B decoding: 49 tokens/s. On 4xA5000 + 1TB host memory, DeepSeek-V2-236B Prefill.Decoding: 3150/196 tokens/s.
+- [2025-03] MoE-Gen V0.1 release. Empower **DeepSeek-R1-671B NO-Quantization** inference on **a single** NVIDIA A5000 with prefill throughput **204 tokens/s**, decoding throughput **17 tokens/s**. Data parallel on multiple devices supported.
 
 # About
 MoE-Gen is an efficient serving engine optimized specifically for **Mixture-of-Expert(MoE)** based large language models. It is tailored for bulk **offline inference** tasks and **limited GPU resources**. It enables low cost serving for latency-insensitive applications.

--- a/moe_gen/models/deepseek/deepseekv2/deepseekv2_initializer.py
+++ b/moe_gen/models/deepseek/deepseekv2/deepseekv2_initializer.py
@@ -506,6 +506,11 @@ class DeepSeek_Initializer:
         self.tensor_meta_shm_name = tensor_meta_shm_name
 
     def _default_engine_config(self):
+        props = torch.cuda.get_device_properties(
+            self.engine_config.Basic_Config.device
+        )
+        total_memory = props.total_memory / (1024**3)
+        logging.info(f"Current device total memory: {total_memory} GB")
         if (
             self.hf_model_config._name_or_path
             == "deepseek-ai/DeepSeek-V2-Lite-Chat"
@@ -672,21 +677,21 @@ class DeepSeek_Initializer:
             )
             if context_length > 768:
                 self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size = math.floor(
-                    10 * 768 / context_length
+                    15 * 768 / context_length
                 )
                 self.engine_config.Module_Batching_Config.MoE_prefill_micro_batch_size = math.floor(
-                    20 * 768 / context_length
+                    30 * 768 / context_length
                 )
             else:
-                self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size = 10
-                self.engine_config.Module_Batching_Config.MoE_prefill_micro_batch_size = 20
+                self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size = 15
+                self.engine_config.Module_Batching_Config.MoE_prefill_micro_batch_size = 30
             logging.info(
                 f"attn_prefill_micro_batch_size: {self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size}"
             )
             logging.info(
                 f"MoE_prefill_micro_batch_size: {self.engine_config.Module_Batching_Config.MoE_prefill_micro_batch_size}"
             )
-            self.engine_config.Module_Batching_Config.expert_prefill_batch_size_upper_bound = 2048
+            self.engine_config.Module_Batching_Config.expert_prefill_batch_size_upper_bound = 4096
 
             if context_length > 768:
                 self.engine_config.Module_Batching_Config.attn_decoding_micro_batch_size = math.floor(
@@ -699,6 +704,16 @@ class DeepSeek_Initializer:
             )
             self.engine_config.Module_Batching_Config.MoE_decoding_micro_batch_size = self.engine_config.Module_Batching_Config.global_batch_size
             self.engine_config.Module_Batching_Config.expert_decoding_batch_size_upper_bound = 2048
+
+            # L40
+            if total_memory >= 47 and total_memory < 49:
+                self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size *= 2
+                self.engine_config.Module_Batching_Config.MoE_prefill_micro_batch_size *= 2
+                self.engine_config.Module_Batching_Config.attn_decoding_micro_batch_size *= 2
+            if total_memory >= 78:
+                self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size *= 3
+                self.engine_config.Module_Batching_Config.MoE_prefill_micro_batch_size *= 3
+                self.engine_config.Module_Batching_Config.attn_decoding_micro_batch_size *= 3
 
             self.engine_config.GPU_Buffer_Config.num_prefill_module_buffer = {
                 "attn": 1,

--- a/moe_gen/models/deepseek/deepseekv2/deepseekv2_initializer.py
+++ b/moe_gen/models/deepseek/deepseekv2/deepseekv2_initializer.py
@@ -670,12 +670,12 @@ class DeepSeek_Initializer:
                 self.engine_config.Basic_Config.max_decoding_length
                 + self.engine_config.Basic_Config.padding_length
             )
-            if context_length > 544:
+            if context_length > 768:
                 self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size = math.floor(
-                    10 * 544 / context_length
+                    10 * 768 / context_length
                 )
                 self.engine_config.Module_Batching_Config.MoE_prefill_micro_batch_size = math.floor(
-                    20 * 544 / context_length
+                    20 * 768 / context_length
                 )
             else:
                 self.engine_config.Module_Batching_Config.attn_prefill_micro_batch_size = 10
@@ -688,9 +688,9 @@ class DeepSeek_Initializer:
             )
             self.engine_config.Module_Batching_Config.expert_prefill_batch_size_upper_bound = 2048
 
-            if context_length > 544:
+            if context_length > 768:
                 self.engine_config.Module_Batching_Config.attn_decoding_micro_batch_size = math.floor(
-                    60 * 544 / context_length
+                    60 * 768 / context_length
                 )
             else:
                 self.engine_config.Module_Batching_Config.attn_decoding_micro_batch_size = 60

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==75.8.2", "wheel==0.45.1", "torch==2.6.0"]
+requires = ["setuptools==75.8.2", "wheel==0.45.1", "torch==2.3.0"]
 build-backend = "setuptools.build_meta"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ protobuf==6.30.0
 psutil==7.0.0
 pybind11==2.12.0
 sentencepiece==0.2.0
-torch==2.6.0
+torch==2.3.0
 transformers==4.42.0


### PR DESCRIPTION
## Description
1. Add about section and 4-devices performance to readme
2. Rolling back to torch==2.3.0 for stable performance.

## Motivation

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Gen/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
